### PR TITLE
Change PAGE_SIZE to 50

### DIFF
--- a/cmds/syncCatalog.js
+++ b/cmds/syncCatalog.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const _ = require('lodash')
 const monstercat = require('../lib/monstercat')
 
-const PAGE_SIZE = 90
+const PAGE_SIZE = 50
 const getPage = (pageNum, results, done)=> {
   if (typeof(results) == 'function') {
     done = results


### PR DESCRIPTION
According to https://connect.monstercat.com/api/catalog/browse, the page limit is 50 (as of time of writing). Having the amount per page higher than the API will allow skips some songs if the number of included songs is above 50 (currently it will get 50 songs, then increase the index by 90, skipping 40 songs).